### PR TITLE
add python3 support, missing requirement

### DIFF
--- a/pynorama/__init__.py
+++ b/pynorama/__init__.py
@@ -1,3 +1,3 @@
-from view import register_view, register_views, View
-from make_server import make_server
-from make_config import make_config
+from .view import register_view, register_views, View
+from .make_server import make_server
+from .make_config import make_config

--- a/pynorama/make_server.py
+++ b/pynorama/make_server.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 from datetime import datetime, date
+from six import iteritems
 from pynorama.exceptions import (JSONRequestBodyRequired, ViewNotFound,
                                  RecordNotFound)
 
@@ -193,7 +194,7 @@ def get_sessions(view_name):
     """Returns a JSON-serialized list of names of all stored sessions."""
     view = get_view(view_name)
     sessions = _session_store.get_sessions(view.get_name())
-    return dumps(sessions.keys())
+    return dumps(list(sessions.keys()))
 
 
 def add_session(view_name):
@@ -301,12 +302,12 @@ def make_server(session_store=InMemorySessionStore()):
         'remove_session': remove_session,
     }
 
-    for key, value in GET_rules.iteritems():
+    for key, value in iteritems(GET_rules):
         app.add_url_rule(base_string + key,
                          key or 'main',
                          value,
                          methods=['GET'])
-    for key, value in POST_rules.iteritems():
+    for key, value in iteritems(POST_rules):
         app.add_url_rule(base_string + key,
                          key or 'main',
                          value,

--- a/pynorama/table/pandas_table.py
+++ b/pynorama/table/pandas_table.py
@@ -2,6 +2,7 @@ import re
 import numpy as np
 import pandas as pd
 import fnmatch
+from six import string_types
 
 from .base_table import Table
 
@@ -154,7 +155,7 @@ def _found(element, searchterm):
     """Return True if a given cell matches the search term, False otherwise"""
     if element is None:
         return False
-    if isinstance(element, basestring):
+    if isinstance(element, string_types):
         return fnmatch.fnmatch(element.strip().lower(), searchterm.strip().lower())
     if isinstance(element, (float, int)):
         # FIXME: This doesn't play nicely with Pandas datetypes

--- a/pynorama/view.py
+++ b/pynorama/view.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from .exceptions import ViewNotFound
 from .logging import logger
+from six import iteritems
 
 
 views = OrderedDict()
@@ -27,7 +28,7 @@ def get_view(name):
 
 
 def list_views():
-    return [view for _, view in views.iteritems()]
+    return [view for _, view in iteritems(views)]
 
 
 class View(object):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     install_requires=[
         'flask',
         'numpy',
-        'pandas'
+        'pandas',
+        'six'
     ],
     extras_require={
         'docs': [
@@ -56,6 +57,7 @@ setup(
         'Topic :: Scientific/Engineering :: Visualization',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7'
+        'Programming Language :: Python :: 3.5'
     ],
     packages=find_packages(
         where='.',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     keywords=['ahl', 'visualization', 'NLP', 'data discovery'],
     url='https://github.com/manahl/pynorama',
     install_requires=[
+        'bson',
         'flask',
         'numpy',
         'pandas',

--- a/tests/unit/sessions/test_json_file.py
+++ b/tests/unit/sessions/test_json_file.py
@@ -16,8 +16,7 @@ def test_load_sessions(workspace):
 
     store = JsonFileSessionStore(workspace.workspace)
     session_data = store.load_sessions('test')
-    assert cmp({"foo": "bar", "xyz": 1, "someday": "2017-12-19T13:18:44.745Z"},
-               session_data) == 0
+    assert {"foo": "bar", "xyz": 1, "someday": "2017-12-19T13:18:44.745Z"} == session_data
 
 
 def test_save_sessions(workspace):
@@ -28,4 +27,4 @@ def test_save_sessions(workspace):
     with open(os.path.join(workspace.workspace, 'test.json'), 'r') as f:
         actual = load(f)
 
-    assert cmp(actual, expected) == 0
+    assert actual == expected

--- a/tests/unit/sessions/test_mongo.py
+++ b/tests/unit/sessions/test_mongo.py
@@ -6,8 +6,7 @@ from mongomock.mongo_client import MongoClient
 def test_load_sessions(mongodb):
     assert 'sessions' in mongodb.collection_names()
     sesstion_data = MongoSessionStore(mongodb.sessions).load_sessions('test')
-    assert cmp({"foo": "bar", "xyz": 1, "someday": "2017-12-19T13:18:44.745Z"},
-               sesstion_data) == 0
+    assert {"foo": "bar", "xyz": 1, "someday": "2017-12-19T13:18:44.745Z"} == sesstion_data
 
 
 def test_save_sessions():
@@ -23,5 +22,4 @@ def test_save_sessions():
     views_data = collection.find_one()
     assert 'view_name' in views_data
     assert views_data.get('view_name') == 'test'
-    assert cmp({"foo": "bar", "xyz": 1, "someday": "2017-12-19T13:18:44.745Z"},
-               views_data.get('sessions')) == 0
+    assert {"foo": "bar", "xyz": 1, "someday": "2017-12-19T13:18:44.745Z"} == views_data.get('sessions')


### PR DESCRIPTION
The tests now pass in python2 (`platform linux2 -- Python 2.7.12, pytest-3.5.1, py-1.5.3, pluggy-0.6.0`) and python3 (`platform linux -- Python 3.5.2, pytest-3.5.1, py-1.5.3, pluggy-0.6.0`)

Addresses https://github.com/manahl/pynorama/issues/22