### PR TITLE
Fix hard-coded path to views

### DIFF
--- a/pynorama/templates/index.html
+++ b/pynorama/templates/index.html
@@ -7,7 +7,7 @@
 <body>
 <ul>
     {% for view in views %}
-    <li><a href="/view/{{ view.get_name() }}/">{{ view.get_description() }}</a></li>
+    <li><a href="{{ url_for('main', view_name=view.get_name()) }}">{{ view.get_description() }}</a></li>
     {% endfor %}
 </ul>
 <div>


### PR DESCRIPTION
Wrap creation of view urls in `url_for` to allow flask internals to correctly build the relative urls.

This is necessary when hosting pynorama behind a proxy such as nginx and for regular setups this will not change behaviour.